### PR TITLE
Group id fix

### DIFF
--- a/OMERO-SIMcheck.py
+++ b/OMERO-SIMcheck.py
@@ -193,8 +193,10 @@ def main_function():
         if do_fourier_plots:
             output_images += fourier_plots(sim_image_title)
 
-        add_images_key_values(gateway, raw_image_measurements, raw_image_id, "SIMcheck")
-        add_images_key_values(gateway, sim_image_measurements, sim_image_id, "SIMcheck")
+        add_images_key_values(gateway, raw_image_measurements, raw_image_id,
+                              group_id, "SIMcheck")
+        add_images_key_values(gateway, sim_image_measurements, sim_image_id,
+                              group_id, "SIMcheck")
 
         for output_image in output_images:
         

--- a/OMERO-SIMcheck.py
+++ b/OMERO-SIMcheck.py
@@ -130,7 +130,7 @@ def main_function():
     gateway = omero_connect(omero_server, omero_port, user_name, user_pw)
 
     # Get Images IDs and names
-    images_dict = get_image_properties(gateway, dataset_id)
+    images_dict = get_image_properties(gateway, dataset_id, group_id)
 
     images = [(images_dict[id]['name'], id) for id in images_dict]
 
@@ -139,7 +139,7 @@ def main_function():
     
     # We are assuming here a standard OMX naming pattern for raw and sim images
     sim_images = [i[0] for i in images if i[0].endswith(sim_subfix)]
-    raw_images = [i[:-len(sim_subfix)] + raw_subfix for i in sim_images]
+    raw_images = [i.rstrip(sim_subfix) + raw_subfix for i in sim_images]
     sim_images_ids = [i for i in images if i[0] in sim_images]
     raw_images_ids = [i for i in images if i[0] in raw_images]
 
@@ -215,7 +215,7 @@ def main_function():
     return gateway.disconnect()
 
 # get OMERO credentials
-#@string(label="Server", value="omero1.bioch.ox.ac.uk", persist=true) omero_server
+#@string(label="Server", value="omero.mri.cnrs.fr", persist=true) omero_server
 #@int(label="Port", value=4064, persist=true) omero_port
 #@string(label="Username", persist=true) user_name
 #@string(label="Password", persist=false) user_pw

--- a/OMERO-SIMcheck.py
+++ b/OMERO-SIMcheck.py
@@ -215,7 +215,7 @@ def main_function():
     return gateway.disconnect()
 
 # get OMERO credentials
-#@string(label="Server", value="omero.mri.cnrs.fr", persist=true) omero_server
+#@string(label="Server", value="omero1.bioch.ox.ac.uk", persist=true) omero_server
 #@int(label="Port", value=4064, persist=true) omero_port
 #@string(label="Username", persist=true) user_name
 #@string(label="Password", persist=false) user_pw

--- a/OMERO-SIMcheck.py
+++ b/OMERO-SIMcheck.py
@@ -139,7 +139,7 @@ def main_function():
     
     # We are assuming here a standard OMX naming pattern for raw and sim images
     sim_images = [i[0] for i in images if i[0].endswith(sim_subfix)]
-    raw_images = [i.rstrip(sim_subfix) + raw_subfix for i in sim_images]
+    raw_images = [i[:-len(sim_subfix)] + raw_subfix for i in sim_images]
     sim_images_ids = [i for i in images if i[0] in sim_images]
     raw_images_ids = [i for i in images if i[0] in raw_images]
 

--- a/OMERO_toolbox.py
+++ b/OMERO_toolbox.py
@@ -91,10 +91,10 @@ def omero_connect(host, port, user_name, user_password):
     return gateway
 
 
-def _get_images_browser(gateway, dataset_id):
+def _get_images_browser(gateway, dataset_id, group_id):
     browse = gateway.getFacility(BrowseFacility)
     user = gateway.getLoggedInUser()
-    ctx = SecurityContext(user.getGroupId())
+    ctx = SecurityContext(group_id)
     ids = ArrayList(1)
     val = Long(dataset_id)
     ids.add(val)
@@ -110,7 +110,7 @@ def get_image_ids(gateway, dataset_id):
     return image_ids
 
 
-def get_image_properties(gateway, dataset_id):
+def get_image_properties(gateway, dataset_id, group_id):
     """Returns a dictionary of dictionaries in the form:
     {long:{'name': str,
            'acquisition_date': ,
@@ -122,7 +122,7 @@ def get_image_properties(gateway, dataset_id):
     under the specified Dataset
     """
 
-    browser = _get_images_browser(gateway, dataset_id)
+    browser = _get_images_browser(gateway, dataset_id, group_id)
     image_properties = {}
     for image in browser:
         image_id = image.getId()

--- a/OMERO_toolbox.py
+++ b/OMERO_toolbox.py
@@ -175,10 +175,10 @@ def upload_image(gateway, path, host, dataset_id):
     return success
 
 
-def _data_manager_generator(gateway):
+def _data_manager_generator(gateway, group_id):
     data_manager = gateway.getFacility(DataManagerFacility)
     user = gateway.getLoggedInUser()
-    ctx = SecurityContext(user.getGroupId())
+    ctx = SecurityContext(group_id)
 
     return data_manager, ctx
 
@@ -196,11 +196,11 @@ def _dict_to_map_annotation(dictionary, description=None):
     return map_data
 
 
-def add_projects_key_values(gateway, key_values, project_ids, description=None):
+def add_projects_key_values(gateway, key_values, project_ids, group_id, description=None):
     """Adds some key:value pairs to a list of images"""
     map_data = _dict_to_map_annotation(key_values, description)
 
-    data_manager, ctx = _data_manager_generator(gateway)
+    data_manager, ctx = _data_manager_generator(gateway, group_id)
 
     # Link the data to the image
     if not hasattr(project_ids, '__iter__'):
@@ -212,11 +212,11 @@ def add_projects_key_values(gateway, key_values, project_ids, description=None):
         data_manager.saveAndReturnObject(ctx, link)
 
 
-def add_datasets_key_values(gateway, key_values, dataset_ids, description=None):
+def add_datasets_key_values(gateway, key_values, dataset_ids, group_id, description=None):
     """Adds some key:value pairs to a list of images"""
     map_data = _dict_to_map_annotation(key_values, description)
 
-    data_manager, ctx = _data_manager_generator(gateway)
+    data_manager, ctx = _data_manager_generator(gateway, group_id)
 
     # Link the data to the image
     if not hasattr(dataset_ids, '__iter__'):
@@ -228,11 +228,11 @@ def add_datasets_key_values(gateway, key_values, dataset_ids, description=None):
         data_manager.saveAndReturnObject(ctx, link)
 
 
-def add_images_key_values(gateway, key_values, image_ids, description=None):
+def add_images_key_values(gateway, key_values, image_ids, group_id, description=None):
     """Adds some key:value pairs to a list of images"""
     map_data = _dict_to_map_annotation(key_values, description)
 
-    data_manager, ctx = _data_manager_generator(gateway)
+    data_manager, ctx = _data_manager_generator(gateway, group_id)
 
     # Link the data to the image
     if not hasattr(image_ids, '__iter__'):


### PR DESCRIPTION
If you have data in your non-default group you cannot access it. As the group id is already passed to the function we should use it to ensure the correct data is accessible. 